### PR TITLE
fix panic when there is no otel name/version

### DIFF
--- a/pkg/tracing/otlp_grpc.go
+++ b/pkg/tracing/otlp_grpc.go
@@ -67,9 +67,9 @@ func (s *TraceServiceServer) process(resourceSpans []*tracepb.ResourceSpans) {
 
 		for _, ils := range rss.InstrumentationLibrarySpans {
 			lib := ils.InstrumentationLibrary
-			resource[xattr.OtelLibraryName] = lib.Name
-			if lib.Version != "" {
-				resource[xattr.OtelLibraryVersion] = lib.Version
+			resource[xattr.OtelLibraryName] = lib.GetName()
+			if lib.GetVersion() != "" {
+				resource[xattr.OtelLibraryVersion] = lib.GetVersion()
 			}
 
 			for _, span := range ils.Spans {


### PR DESCRIPTION
when otel.library.name and otel.library.version is not provided uptrace crashes
opentelemetry-rust doesn't provide them in grpc so it crashes uptrace.
```
read the docs at            https://docs.uptrace.dev/guide/os.html#otlp
OTLP/gRPC (listen.grpc)     http://localhost:14317
OTLP/HTTP (listen.http)     http://localhost:14318
UI (listen.http)            http://localhost:14318/

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x16bc329]

goroutine 72 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	go.opentelemetry.io/otel/sdk@v1.3.0/trace/span.go:243 +0x2a
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00023a480, {0x0, 0x0, 0x120?})
	go.opentelemetry.io/otel/sdk@v1.3.0/trace/span.go:282 +0x8a2
panic({0x179c9c0, 0x2ac8490})
	runtime/panic.go:838 +0x207
github.com/uptrace/uptrace/pkg/tracing.(*TraceServiceServer).process(0xc000098000, {0xc00071c1a8, 0x1, 0x17b0940?})
	github.com/uptrace/uptrace/pkg/tracing/otlp_grpc.go:70 +0x129
github.com/uptrace/uptrace/pkg/tracing.(*TraceServiceServer).Export(0x2?, {0x25e39a8?, 0xc0003fa870?}, 0xc000716100)
	github.com/uptrace/uptrace/pkg/tracing/otlp_grpc.go:60 +0x6d
go.opentelemetry.io/proto/otlp/collector/trace/v1._TraceService_Export_Handler.func1({0x25e39a8, 0xc0003fa870}, {0x17ed860?, 0xc000716100})
	go.opentelemetry.io/proto/otlp@v0.11.0/collector/trace/v1/trace_service_grpc.pb.go:85 +0x78
go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1({0x25e39a8, 0xc0007120c0}, {0x17ed860, 0xc000716100}, 0xc0001fe6e0, 0xc000554900)
	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.27.0/interceptor.go:325 +0x664
go.opentelemetry.io/proto/otlp/collector/trace/v1._TraceService_Export_Handler({0x1870a40?, 0xc000098000}, {0x25e39a8, 0xc0007120c0}, 0xc000100360, 0xc0001ff640)
	go.opentelemetry.io/proto/otlp@v0.11.0/collector/trace/v1/trace_service_grpc.pb.go:87 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00043afc0, {0x25e62f8, 0xc000112180}, 0xc000128000, 0xc0000a4060, 0x2ac9de0, 0x0)
	google.golang.org/grpc@v1.42.0/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc00043afc0, {0x25e62f8, 0xc000112180}, 0xc000128000, 0x0)
	google.golang.org/grpc@v1.42.0/server.go:1616 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.42.0/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.42.0/server.go:919 +0x28a
```