### PR TITLE
feat: read cLoki samples from the DB

### DIFF
--- a/config/uptrace.yml
+++ b/config/uptrace.yml
@@ -20,6 +20,11 @@ ch:
   # clickhouse://<user>:<password>@<host>:<port>/<database>?sslmode=disable
   dsn: 'clickhouse://default:@localhost:9000/uptrace?sslmode=disable'
 
+cloki_db:
+  # Connection string for ClickHouse database.
+  # clickhouse://<user>:<password>@<host>:<port>/<database>?sslmode=disable
+  dsn: 'clickhouse://default:@localhost:9000/cloki?sslmode=disable'
+
 retention:
   # Tell ClickHouse to delete data after 30 days.
   # Supports SQL interval syntax, for example, INTERVAL 30 DAY.

--- a/pkg/bunapp/config.go
+++ b/pkg/bunapp/config.go
@@ -9,6 +9,41 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type AppConfig struct {
+	Filepath string `yaml:"-"`
+	Service  string `yaml:"service"`
+
+	Debug     bool   `yaml:"debug"`
+	SecretKey string `yaml:"secret_key"`
+
+	Site struct {
+		Scheme string `yaml:"scheme"`
+		Host   string `yaml:"host"`
+	} `yaml:"site"`
+
+	Listen struct {
+		HTTP string `yaml:"http"`
+		GRPC string `yaml:"grpc"`
+
+		HTTPHost string `yaml:"-"`
+		HTTPPort string `yaml:"-"`
+
+		GRPCHost string `yaml:"-"`
+		GRPCPort string `yaml:"-"`
+	} `yaml:"listen"`
+
+	DB      BunConfig `yaml:"db"`
+	CH      CHConfig  `yaml:"ch"`
+	ClokiDB CHConfig  `yaml:"cloki_db"`
+
+	Retention struct {
+		TTL string `yaml:"ttl"`
+	} `yaml:"retention"`
+
+	Users    []User    `yaml:"users"`
+	Projects []Project `yaml:"projects"`
+}
+
 func ReadConfig(configFile, service string) (*AppConfig, error) {
 	configFile, err := filepath.Abs(configFile)
 	if err != nil {
@@ -69,40 +104,6 @@ func validateProjects(projects []Project) error {
 	}
 
 	return nil
-}
-
-type AppConfig struct {
-	Filepath string `yaml:"-"`
-	Service  string `yaml:"service"`
-
-	Debug     bool   `yaml:"debug"`
-	SecretKey string `yaml:"secret_key"`
-
-	Site struct {
-		Scheme string `yaml:"scheme"`
-		Host   string `yaml:"host"`
-	} `yaml:"site"`
-
-	Listen struct {
-		HTTP string `yaml:"http"`
-		GRPC string `yaml:"grpc"`
-
-		HTTPHost string `yaml:"-"`
-		HTTPPort string `yaml:"-"`
-
-		GRPCHost string `yaml:"-"`
-		GRPCPort string `yaml:"-"`
-	} `yaml:"listen"`
-
-	DB BunConfig `yaml:"db"`
-	CH CHConfig  `yaml:"ch"`
-
-	Retention struct {
-		TTL string `yaml:"ttl"`
-	} `yaml:"retention"`
-
-	Users    []User    `yaml:"users"`
-	Projects []Project `yaml:"projects"`
 }
 
 type User struct {

--- a/pkg/tracing/cloki_handler.go
+++ b/pkg/tracing/cloki_handler.go
@@ -1,0 +1,67 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/uptrace/bunrouter"
+	"github.com/uptrace/uptrace/pkg/bunapp"
+	"github.com/uptrace/uptrace/pkg/httputil"
+	"github.com/uptrace/uptrace/pkg/urlstruct"
+)
+
+type ClokiFilter struct {
+	*bunapp.App `urlstruct:"-"`
+
+	TimeFilter
+
+	TraceID string
+}
+
+func DecodeClokiFilter(app *bunapp.App, req bunrouter.Request) (*ClokiFilter, error) {
+	f := &ClokiFilter{App: app}
+	if err := bunapp.UnmarshalValues(req, f); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+var _ urlstruct.ValuesUnmarshaler = (*ClokiFilter)(nil)
+
+func (f *ClokiFilter) UnmarshalValues(ctx context.Context, values url.Values) error {
+	if err := f.TimeFilter.UnmarshalValues(ctx, values); err != nil {
+		return err
+	}
+	return nil
+}
+
+//------------------------------------------------------------------------------
+
+type ClokiHandler struct {
+	*bunapp.App
+}
+
+func NewClokiHandler(app *bunapp.App) *ClokiHandler {
+	return &ClokiHandler{
+		App: app,
+	}
+}
+
+func (h *ClokiHandler) ListSamples(w http.ResponseWriter, req bunrouter.Request) error {
+	ctx := req.Context()
+
+	f, err := DecodeClokiFilter(h.App, req)
+	if err != nil {
+		return err
+	}
+
+	samples, err := SelectClokiSamples(ctx, h.App, f)
+	if err != nil {
+		return err
+	}
+
+	return httputil.JSON(w, bunrouter.H{
+		"samples": samples,
+	})
+}

--- a/pkg/tracing/cloki_sample.go
+++ b/pkg/tracing/cloki_sample.go
@@ -1,0 +1,43 @@
+package tracing
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/uptrace/go-clickhouse/ch"
+	"github.com/uptrace/uptrace/pkg/bunapp"
+)
+
+type ClokiSample struct {
+	ch.CHModel `ch:"table:samples_read_v2_2,alias:s"`
+
+	String string         `json:"string"`
+	Time   time.Time      `json:"time" ch:"type:DateTime64"`
+	Labels map[string]any `json:"labels" ch:",json"`
+}
+
+func SelectClokiSamples(
+	ctx context.Context, app *bunapp.App, f *ClokiFilter,
+) ([]*ClokiSample, error) {
+	s1 := f.TraceID                       // UUID v4
+	s2 := strings.ReplaceAll(s1, "-", "") // UUID v4 without '-'
+
+	samples := make([]*ClokiSample, 0)
+
+	if err := app.ClokiDB().NewSelect().
+		ColumnExpr("s.string").
+		ColumnExpr("toDateTime64(s.timestamp_ns / 1e9, 6) AS time").
+		ColumnExpr("ts.labels").
+		Model(&samples).
+		Join("LEFT JOIN time_series AS ts ON ts.fingerprint = s.fingerprint").
+		Where("timestamp_ns >= ?", f.TimeGTE.UnixNano()).
+		Where("timestamp_ns < ?", f.TimeLT.UnixNano()).
+		Where("multiSearchAny(string, [?, ?])", s1, s2).
+		Limit(10000).
+		Scan(ctx); err != nil {
+		return nil, err
+	}
+
+	return samples, nil
+}

--- a/pkg/tracing/init.go
+++ b/pkg/tracing/init.go
@@ -37,10 +37,12 @@ func registerRoutes(ctx context.Context, app *bunapp.App) error {
 	spanHandler := NewSpanHandler(app)
 	traceHandler := NewTraceHandler(app)
 	suggestionHandler := NewSuggestionHandler(app)
+	clokiHandler := NewClokiHandler(app)
 
 	api := app.APIGroup()
 
 	api.GET("/traces/:trace_id", traceHandler.FindTrace)
+	api.GET("/cloki/:project_id/samples", clokiHandler.ListSamples)
 
 	g := api.
 		Use(org.NewAuthMiddleware(app)).

--- a/pkg/tracing/span_data.go
+++ b/pkg/tracing/span_data.go
@@ -60,15 +60,14 @@ func SelectTraceSpans(ctx context.Context, app *bunapp.App, traceID uuid.UUID) (
 		return nil, err
 	}
 
-	spans := make([]*Span, len(data))
+	spans := make([]*Span, 0, len(data))
 
-	for i, span := range spans {
-		span = new(Span)
-		spans[i] = span
-
-		if err := unmarshalSpan(data[i].Data, span); err != nil {
+	for _, sd := range data {
+		span := new(Span)
+		if err := unmarshalSpan(sd.Data, span); err != nil {
 			return nil, err
 		}
+		spans = append(spans, span)
 	}
 
 	return spans, nil

--- a/vue/src/components/ClokiSamples.vue
+++ b/vue/src/components/ClokiSamples.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-simple-table>
+    <tbody>
+      <tr v-for="(sample, i) in items" :key="i">
+        <td class="text-no-wrap"><XDate :date="sample.time" format="full" /></td>
+        <td>{{ sample.string }}</td>
+      </tr>
+    </tbody>
+  </v-simple-table>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from '@vue/composition-api'
+
+// Composables
+import { Sample } from '@/use/cloki'
+
+export default defineComponent({
+  name: 'ClokiSamples',
+
+  props: {
+    items: {
+      type: Array as PropType<Sample[]>,
+      required: true,
+    },
+  },
+})
+</script>

--- a/vue/src/use/cloki.ts
+++ b/vue/src/use/cloki.ts
@@ -1,0 +1,29 @@
+import { computed, proxyRefs } from '@vue/composition-api'
+
+import { useWatchAxios, AxiosRequestSource } from '@/use/watch-axios'
+
+export type UseClokiSample = ReturnType<typeof useClokiSamples>
+
+export interface Sample {
+  string: string
+  time: string
+  labels: Record<string, any>
+}
+
+export function useClokiSamples(reqSource: AxiosRequestSource) {
+  const { loading, data, reload } = useWatchAxios(() => {
+    return reqSource()
+  })
+
+  const samples = computed((): Sample[] => {
+    const samples = data.value?.samples ?? []
+    return samples
+  })
+
+  return proxyRefs({
+    loading,
+    items: samples,
+
+    reload,
+  })
+}


### PR DESCRIPTION
In this PR, Uptrace reads logs directly from cLoki database and displays them when users view traces. To do that, Uptrace filters log messages that contain the current trace id.

To generate logs with trace ids, I've used the [example](https://github.com/uptrace/uptrace-go/pull/118) based on Vector that exports logs to cLoki. The readme should explain how to run it.

cLoki UI:

![cloki](https://user-images.githubusercontent.com/290976/166151212-0da089da-9a3c-46a9-8bb5-e4ff308d5701.png)

cLoki samples shown in Uptrace UI:

![cloki-uptrace](https://user-images.githubusercontent.com/290976/166151215-7807fe28-8c0d-4216-834d-5846098d6334.png)
