### PR TITLE
Add user templates

### DIFF
--- a/config/uptrace.yml
+++ b/config/uptrace.yml
@@ -46,6 +46,13 @@ projects:
 #     password: uptrace
 
 ##
+## You can also configure groups of users that share the same token audience.
+##
+# user_templates:
+#   - id: 2
+#     audience: uptrace-users
+
+##
 ## ClickHouse database credentials.
 ##
 ch:

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/codemodus/kace v0.5.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/klauspost/compress v1.15.9
 	github.com/mileusna/useragent v1.1.0
 	github.com/mostynb/go-grpc-compression v1.1.16

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -217,6 +215,8 @@ github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=

--- a/pkg/bunconf/config.go
+++ b/pkg/bunconf/config.go
@@ -177,8 +177,9 @@ type Config struct {
 		BatchSize  int `yaml:"batch_size"`
 	} `yaml:"metrics"`
 
-	Users    []User    `yaml:"users"`
-	Projects []Project `yaml:"projects"`
+	Users         []User         `yaml:"users"`
+	UserTemplates []UserTemplate `yaml:"user_templates"`
+	Projects      []Project      `yaml:"projects"`
 
 	Alerting struct {
 		Rules []AlertRule `yaml:"rules"`
@@ -237,6 +238,11 @@ type User struct {
 	ID       uint64 `yaml:"id" json:"id"`
 	Username string `yaml:"username" json:"username"`
 	Password string `yaml:"password" json:"-"`
+}
+
+type UserTemplate struct {
+	ID       uint64 `yaml:"id" json:"id"`
+	Audience string `yaml:"audience" json:"audience"`
 }
 
 type Project struct {

--- a/vue/src/use/org.ts
+++ b/vue/src/use/org.ts
@@ -8,7 +8,7 @@ import { useAxios } from '@/use/axios'
 
 export interface User {
   id: number
-  name: string
+  username: string
 }
 
 export interface Project {
@@ -20,7 +20,7 @@ export const useUser = defineStore(() => {
   const { loading, data, request } = useAxios()
 
   const user = computed((): User => {
-    return data.value?.user ?? { id: 0, name: 'Guest' }
+    return data.value?.user ?? { id: 0, username: 'Guest' }
   })
 
   const isAuth = computed((): boolean => {


### PR DESCRIPTION
## Why

Creating new users requires a configuration update and restart. This patch allows external auth providers to submit valid tokens with arbitrary usernames, so that users do not need to maintain uptrace credentials.

Addresses #76 as a first step. This implementation can be extended to have native support for some common auth providers.

## How

Allows configuring 'user templates', which resolves the user ID based on the configured audience (`aud`) of the token. The subject (`sub`) is then used as the username. This allows external auth providers to sign valid Uptrace JWTs, while passing an arbitrary username.

Replaced deprecated jwt library https://github.com/dgrijalva/jwt-go with https://github.com/golang-jwt/jwt.

Administrators may need to write their own scripts to map external provider JWTs to valid Uptrace ones; for example validating and converting a Cloudflare Access JWT and mapping the `email` claim to `sub`, and setting the configured audience. The script can MITM uptrace to set the `token` cookie.

This implementation is vendor-agnostic by design, as to allow any auth service to be integrated (LDAP, PKI, Cloudflare, etc.) in front of Uptrace. It also minimizes the amount of auth code to add to Uptrace.

## Future Considerations

1. Consider passing `user.id` and `user.username` in uptrace internal spans for auditing purposes.
2. Consider supporting _some_ external auth providers as built-ins, such as LDAP, SSO, Cloudflare, etc. This could be configured as a property of each `user_template` entry.

## Example

With the following `uptrace.yml` snippet:

```yml
user_templates:
   - id: 2
     audience: uptrace-users

secret_key: 102c1a557c314fc28198acd017960843
```

We can generate a token using the [`jwt-cli`](https://github.com/mike-engel/jwt-cli):

```
$ jwt encode --secret 102c1a557c314fc28198acd017960843 '{"sub": "amperes", "aud": "uptrace-users"}'
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJ1cHRyYWNlLXVzZXJzIiwiaWF0IjoxNjYyOTMxNDQ4LCJzdWIiOiJhbXBlcmVzIn0.SBxfygB9Fw9nOZaOVrtz6HOLTr3H5TM5XLaoZ7rFlbs
```

Setting this token as the `token` cookie automatically signs into uptrace:

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/6775216/189549964-23cc5dae-e497-4e92-bdae-d1f0a960ebf6.png">
