### PR TITLE
fix: duration units in group table

### DIFF
--- a/vue/src/util/fmt/index.ts
+++ b/vue/src/util/fmt/index.ts
@@ -24,18 +24,18 @@ export function createFormatter(unit: string | Unit | Formatter): Formatter {
     case Unit.Date:
       return datetime
     case Unit.Nanoseconds:
-      return (val: any, ...args: any[]) => {
-        return duration(adjustNumber(val, 0.001), ...args)
-      }
-    case Unit.Microseconds:
       return duration
-    case Unit.Milliseconds:
+    case Unit.Microseconds:
       return (val: any, ...args: any[]) => {
         return duration(adjustNumber(val, 1e3), ...args)
       }
-    case Unit.Seconds:
+    case Unit.Milliseconds:
       return (val: any, ...args: any[]) => {
         return duration(adjustNumber(val, 1e6), ...args)
+      }
+    case Unit.Seconds:
+      return (val: any, ...args: any[]) => {
+        return duration(adjustNumber(val, 1e9), ...args)
       }
     case Unit.Bytes:
       return bytes
@@ -50,18 +50,18 @@ export function createShortFormatter(unit: Unit | string): Formatter {
     case Unit.Date:
       return datetime
     case Unit.Nanoseconds:
-      return (val: any, ...args: any[]) => {
-        return durationShort(adjustNumber(val, 0.001), ...args)
-      }
-    case Unit.Microseconds:
       return durationShort
-    case Unit.Milliseconds:
+    case Unit.Microseconds:
       return (val: any, ...args: any[]) => {
         return durationShort(adjustNumber(val, 1e3), ...args)
       }
-    case Unit.Seconds:
+    case Unit.Milliseconds:
       return (val: any, ...args: any[]) => {
         return durationShort(adjustNumber(val, 1e6), ...args)
+      }
+    case Unit.Seconds:
+      return (val: any, ...args: any[]) => {
+        return durationShort(adjustNumber(val, 1e9), ...args)
       }
     case Unit.Bytes:
       return bytesShort
@@ -97,7 +97,7 @@ function noneShort(v: unknown): string {
 
 function adjustNumber(v: any, mod: number): any {
   if (typeof v === 'number') {
-    return v * mod
+    return v / mod
   }
   return v
 }


### PR DESCRIPTION
Fixes #93 

The issue was that the API returns `nanoseconds`, but the formatter's logic was as if the API returned `microseconds`. Not sure if that's because the API changed at some point, or maybe there's a discrepancy somewhere else.

Before:

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/6775216/191657315-52b5e741-4b66-46e8-accd-2ed247c41bb4.png">


After:

<img width="1438" alt="Screen Shot 2022-09-22 at 12 09 45 AM" src="https://user-images.githubusercontent.com/6775216/191657098-229c9136-d8e8-467a-872b-8710d4459bb3.png">
