### PR TITLE
fix: Update uptrace container tag

### DIFF
--- a/example/docker/docker-compose.yaml
+++ b/example/docker/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - '9000:9000'
 
   uptrace:
-    image: 'uptrace/uptrace:1.1'
+    image: 'uptrace/uptrace:1.1.0'
     #image: 'uptrace/uptrace-dev:latest'
     restart: on-failure
     volumes:


### PR DESCRIPTION
Pulling tag 1.1 from Docker hub results in the following error as the tag does not exist:

Pulling uptrace (uptrace/uptrace:1.1)...
ERROR: manifest for uptrace/uptrace:1.1 not found: manifest unknown: manifest unknown