### PR TITLE
fix: use empty timeseries when joining

### DIFF
--- a/pkg/metrics/upql/engine.go
+++ b/pkg/metrics/upql/engine.go
@@ -253,8 +253,8 @@ func (e *Engine) join(
 
 		ts1, ok := m[hash]
 		if !ok {
-			joined = append(joined, *ts2)
-			continue
+			joined = append(joined, newTimeseriesFrom(ts2))
+			ts1 = &joined[len(joined)-1]
 		}
 
 		value := make([]float64, len(ts1.Value))


### PR DESCRIPTION
Closes https://github.com/uptrace/uptrace/pull/163

This is already deployed in the cloud version so you can experiment [there](https://app.uptrace.dev/metrics/1/817370621905207298?time_gte=20230211T063700&time_dur=3600&sort_by=spans_per_min&sort_desc=1).