### PR TITLE
fix(docker): signal processing for docker container

### DIFF
--- a/cmd/uptrace/entrypoint.sh
+++ b/cmd/uptrace/entrypoint.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 if [ $# -eq 0 ]; then
     /uptrace --config=/etc/uptrace/uptrace.yml ch wait
-    /uptrace --config=/etc/uptrace/uptrace.yml serve
+    exec /uptrace --config=/etc/uptrace/uptrace.yml serve
 else
-    /uptrace --config=/etc/uptrace/uptrace.yml $@
+    exec /uptrace --config=/etc/uptrace/uptrace.yml $@
 fi


### PR DESCRIPTION
When using entrypoint shell script it's important to start the actual process by using exec to allow correctly processing signals from docker (term/kill), this allows graceful shutdown.

https://stackoverflow.com/questions/32255814/what-purpose-does-using-exec-in-docker-entrypoint-scripts-serve

currently this leads to the shell remaining as top process and uptrace not receiving signals:
```
/ # pstree -p
entrypoint.sh(1)---uptrace(13)-+-{uptrace}(14)
                               |-{uptrace}(15)
                               |-{uptrace}(16)
                               |-{uptrace}(17)
                               |-{uptrace}(18)
                               |-{uptrace}(19)
                               |-{uptrace}(20)
                               |-{uptrace}(21)
                               `-{uptrace}(22)
```