### PR TITLE
fix: sentry_key parsing

### DIFF
--- a/pkg/tracing/sentry_handler.go
+++ b/pkg/tracing/sentry_handler.go
@@ -446,10 +446,11 @@ func (h *SentryHandler) sentryKey(req bunrouter.Request) (string, error) {
 
 	var sentryKey string
 
-	for _, kv := range strings.Split(auth, ", ") {
+	for _, kv := range strings.Split(auth, ",") {
+		kv_trimmed := strings.Trim(kv, " ")
 		const prefix = "sentry_key="
-		if strings.HasPrefix(kv, prefix) {
-			sentryKey = strings.TrimPrefix(kv, prefix)
+		if strings.HasPrefix(kv_trimmed, prefix) {
+			sentryKey = strings.TrimPrefix(kv_trimmed, prefix)
 			break
 		}
 	}


### PR DESCRIPTION
To support https://github.com/getsentry/sentry-dart/pull/1395 and resolve the following error:

```
{
  "status": 400,
  "code": "bad_request",
  "message": "sentry: can't find sentry_key in \"Sentry sentry_version=7,sentry_client=sentry.java.android.flutter/6.17.0,sentry_key=[Redacted]\""
}
```