### PR TITLE
feat(oidc): added the ability to display the username in web UI

### DIFF
--- a/pkg/bunconf/org.go
+++ b/pkg/bunconf/org.go
@@ -16,14 +16,15 @@ type CloudflareProvider struct {
 }
 
 type OIDCProvider struct {
-	ID           string   `yaml:"id" json:"id"`
-	DisplayName  string   `yaml:"display_name" json:"display_name"`
-	IssuerURL    string   `yaml:"issuer_url" json:"issuer_url"`
-	ClientID     string   `yaml:"client_id" json:"client_id"`
-	ClientSecret string   `yaml:"client_secret" json:"client_secret"`
-	RedirectURL  string   `yaml:"redirect_url" json:"redirect_url"`
-	Scopes       []string `yaml:"scopes" json:"scopes"`
-	Claim        string   `yaml:"claim" json:"claim"`
+	ID            string   `yaml:"id" json:"id"`
+	DisplayName   string   `yaml:"display_name" json:"display_name"`
+	IssuerURL     string   `yaml:"issuer_url" json:"issuer_url"`
+	ClientID      string   `yaml:"client_id" json:"client_id"`
+	ClientSecret  string   `yaml:"client_secret" json:"client_secret"`
+	RedirectURL   string   `yaml:"redirect_url" json:"redirect_url"`
+	Scopes        []string `yaml:"scopes" json:"scopes"`
+	Claim         string   `yaml:"claim" json:"claim"`
+	NameAttribute string   `yaml:"name_attribute" json:"name_attribute"`
 }
 
 type Project struct {

--- a/pkg/org/sso_handler.go
+++ b/pkg/org/sso_handler.go
@@ -202,6 +202,11 @@ func (h *SSOMethodHandler) exchange(
 	var email string
 	emailClaim := (*claims)[claim]
 
+	var username string
+	if len(h.conf.NameAttribute) > 0 {
+		username = (*claims)[h.conf.NameAttribute].(string)
+	}
+
 	switch emailClaim := emailClaim.(type) {
 	case string:
 		email = emailClaim
@@ -217,6 +222,7 @@ func (h *SSOMethodHandler) exchange(
 
 	user := &User{
 		Email: email,
+		Name:  username,
 	}
 	user.Init()
 

--- a/pkg/org/user_provider.go
+++ b/pkg/org/user_provider.go
@@ -2,7 +2,6 @@ package org
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -50,12 +49,6 @@ func (p *JWTProvider) Auth(req bunrouter.Request) (*User, error) {
 
 	user, err := SelectUserByEmail(ctx, p.app, email)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			user := &User{
-				Email: email,
-			}
-			user.Init()
-		}
 		return nil, err
 	}
 	return user, nil

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -51,7 +51,7 @@
                 <v-list-item>
                   <v-list-item-content>
                     <v-list-item-title class="font-weight-bold">
-                      {{ user.current.username || 'Anonymous' }}
+                      {{ user.current.name || 'Anonymous' }}
                     </v-list-item-title>
                     <v-list-item-subtitle v-if="user.current.email">
                       {{ user.current.email }}


### PR DESCRIPTION
Added saving new users successfully authenticated by OIDC to the database.
Fixed display of the username in the web interface.

Added new option `name_attribute`. If the option is specified, then the user is assigned a name equal to the value of the `name_attribute` key from OIDC userinfo.
The recommended value for Keycloak Auth and Google Cloud Auth is name.
An example of Keycloak userinfo:
```
{
  "sub": "ddce23a1-2b75-526b-8f10-8a53f826323e",
  "email_verified": false,
  "name": "John Doe",
  "preferred_username": "johndoe",
  "given_name": "John",
  "family_name": "Doe",
  "email": "johndoe@gmail.com"
}
```