### PR TITLE
fix: sentry handler should handle the case where sentry_key is the first paramters in the X-Sentry-Auth header

### DIFF
--- a/pkg/tracing/sentry_handler.go
+++ b/pkg/tracing/sentry_handler.go
@@ -447,7 +447,8 @@ func (h *SentryHandler) sentryKey(req bunrouter.Request) (string, error) {
 	}
 
 	var sentryKey string
-
+        
+	auth = strings.TrimPrefix(auth, "Sentry ")
 	for _, kv := range strings.Split(auth, ",") {
 		kv = strings.Trim(kv, " ")
 		const prefix = "sentry_key="


### PR DESCRIPTION
e.g.

```
X-Sentry-Auth: Sentry sentry_key=xxxxxx, ...
```