### PR TITLE
feat: propagate query params

### DIFF
--- a/vue/src/tracing/views/TraceFind.vue
+++ b/vue/src/tracing/views/TraceFind.vue
@@ -53,6 +53,7 @@ export default defineComponent({
               projectId: String(span.projectId),
               traceId: span.traceId,
             },
+            query: route.value.query,
           })
         }
       },


### PR DESCRIPTION
This PR allows to propagate the query params from `TraceFind` component to `TraceShow`, thanks to this we can access the span directly using the `span` query param in the cloud version.
I managed to test it on local but doesn't "work" since `span` in query seems to work only in Uptrace Cloud.