### PR TITLE
fix: sort data in groups query

### DIFF
--- a/pkg/tracing/span_filter.go
+++ b/pkg/tracing/span_filter.go
@@ -64,6 +64,9 @@ func (f *SpanFilter) UnmarshalValues(ctx context.Context, values url.Values) err
 	if err := f.Pager.UnmarshalValues(ctx, values); err != nil {
 		return err
 	}
+	if err := f.OrderByMixin.UnmarshalValues(ctx, values); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -144,6 +147,9 @@ func buildSpanIndexQuery(
 	app *bunapp.App, f *SpanFilter, dur time.Duration,
 ) (*ch.SelectQuery, *orderedmap.OrderedMap[string, *ColumnInfo]) {
 	q := NewSpanIndexQuery(app).Apply(f.whereClause)
+	if f.OrderByMixin.SortBy != "" {
+		q = q.Order(fmt.Sprintf("%s %s", f.OrderByMixin.SortBy, f.OrderByMixin.SortDir()))
+	}
 	return compileUQL(q, f.parts, dur)
 }
 


### PR DESCRIPTION
https://github.com/uptrace/uptrace/issues/260
UI paginates the data by the order in which it was received in a response and then sorts it inside the page. This change sorts the data for proper pagination. It does not solve the issue of changing sort order inside the page which will be addressed on UI side.