### PR TITLE
ForceSpanName project setting

### DIFF
--- a/cmd/uptrace/main.go
+++ b/cmd/uptrace/main.go
@@ -402,6 +402,7 @@ func loadInitialData(ctx context.Context, app *bunapp.App) error {
 			GroupByEnv:          src.GroupByEnv,
 			GroupFuncsByService: src.GroupFuncsByService,
 			PromCompat:          src.PromCompat,
+			ForceSpanName:       src.ForceSpanName,
 		}
 		if err := dest.Init(); err != nil {
 			return err
@@ -428,6 +429,7 @@ func createProject(ctx context.Context, app *bunapp.App, project *org.Project) e
 		Set("group_by_env = EXCLUDED.group_by_env").
 		Set("group_funcs_by_service = EXCLUDED.group_funcs_by_service").
 		Set("prom_compat = EXCLUDED.prom_compat").
+		Set("force_span_name = EXCLUDED.force_span_name").
 		Set("updated_at = EXCLUDED.updated_at").
 		Returning("*").
 		Exec(ctx); err != nil {

--- a/config/uptrace.dist.yml
+++ b/config/uptrace.dist.yml
@@ -62,7 +62,7 @@ projects:
     group_funcs_by_service: false
     # Enable prom_compat if you want to use the project as a Prometheus datasource in Grafana.
     prom_compat: true
-    # Show the original span name instead of SQL statement for DB spans
+    # Show the original span name instead of SQL statement for DB spans (only affects new spans)
     force_span_name: false
 
   # Other projects can be used to monitor your applications.

--- a/config/uptrace.dist.yml
+++ b/config/uptrace.dist.yml
@@ -62,6 +62,8 @@ projects:
     group_funcs_by_service: false
     # Enable prom_compat if you want to use the project as a Prometheus datasource in Grafana.
     prom_compat: true
+    # Show the original span name instead of SQL statement for DB spans
+    force_span_name: false
 
   # Other projects can be used to monitor your applications.
   # To monitor micro-services or multiple related services, use a single project.
@@ -73,6 +75,7 @@ projects:
       - host_name
       - deployment_environment
     prom_compat: true
+    force_span_name: false
 
 ##
 ## Create metrics from spans and events.

--- a/config/uptrace.yml
+++ b/config/uptrace.yml
@@ -62,6 +62,8 @@ projects:
     group_funcs_by_service: false
     # Enable prom_compat if you want to use the project as a Prometheus datasource in Grafana.
     prom_compat: true
+    # Show the original span name instead of SQL statement for DB spans
+    force_span_name: false
 
   # Other projects can be used to monitor your applications.
   # To monitor micro-services or multiple related services, use a single project.
@@ -73,6 +75,7 @@ projects:
       - host_name
       - deployment_environment
     prom_compat: true
+    force_span_name: false
 
 auth:
   users:

--- a/config/uptrace.yml
+++ b/config/uptrace.yml
@@ -62,7 +62,7 @@ projects:
     group_funcs_by_service: false
     # Enable prom_compat if you want to use the project as a Prometheus datasource in Grafana.
     prom_compat: true
-    # Show the original span name instead of SQL statement for DB spans
+    # Show the original span name instead of SQL statement for DB spans (only affects new spans)
     force_span_name: false
 
   # Other projects can be used to monitor your applications.

--- a/pkg/bunapp/pgmigrations/20240202182031_add_force_span_name.up.sql
+++ b/pkg/bunapp/pgmigrations/20240202182031_add_force_span_name.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE projects
+ADD COLUMN force_span_name BOOLEAN NOT NULL DEFAULT FALSE;

--- a/pkg/bunconf/org.go
+++ b/pkg/bunconf/org.go
@@ -35,4 +35,5 @@ type Project struct {
 	GroupByEnv          bool     `yaml:"group_by_env"`
 	GroupFuncsByService bool     `yaml:"group_funcs_by_service"`
 	PromCompat          bool     `yaml:"prom_compat"`
+	ForceSpanName       bool     `yaml:"force_span_name"`
 }

--- a/pkg/org/project.go
+++ b/pkg/org/project.go
@@ -23,6 +23,7 @@ type Project struct {
 	GroupByEnv          bool     `json:"groupByEnv"`
 	GroupFuncsByService bool     `json:"groupFuncsByService"`
 	PromCompat          bool     `json:"promCompat"`
+	ForceSpanName       bool     `json:"forceSpanName"`
 
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`

--- a/pkg/tracing/span_attrs.go
+++ b/pkg/tracing/span_attrs.go
@@ -392,7 +392,7 @@ func assignSpanSystemAndGroupID(ctx *spanContext, project *org.Project, span *Sp
 				hashDBStmt(digest, stmt)
 			}
 		})
-		if stmt != "" {
+		if !project.ForceSpanName && stmt != "" {
 			span.DisplayName = stmt
 		}
 		return


### PR DESCRIPTION
See #324.

This PR adds the `ForceSpanName` project setting which makes the original span name be shown instead of SQL statements for database spans. Unfortunately it seems that this setting only affects new spans, while old spans (before the setting is changed) remain the same.

I'm not sure if "Force" sounds good, if you have a better suggestion I'm happy to change it!

`force_span_name: false` (default, old behavior)
![2024-02-02 15-58-01](https://github.com/uptrace/uptrace/assets/75134774/fa11f585-3617-4e51-b08b-f1cda5b47201)

`force_span_name: true`
![2024-02-02 15-58-13](https://github.com/uptrace/uptrace/assets/75134774/a575a7ac-5b0b-4cb7-a34a-64bc6f6c79b4)

Edit: I've noticed a few errors related to ClickHouse but I'm unsure if they are related to this PR:
```
[ch]  16:06:42.151   INSERT                     0s  INSERT INTO "spans_data_buffer" ("type", "project_id", "trace_id", "id", "parent_id", "time", "data") VALUES       *ch.Error: DB::NetException: Unexpected packet Data received from client (101) 
2024-02-02T16:06:42.151-0300    error   tracing/span_processor.go:235   ch.Insert failed        {"error": "DB::NetException: Unexpected packet Data received from client (101)", "table": "spans_data"}
github.com/uptrace/uptrace/pkg/tracing.(*SpanProcessor)._processSpans
        uptrace/pkg/tracing/span_processor.go:235
github.com/uptrace/uptrace/pkg/tracing.(*SpanProcessor).processSpans.func1
        uptrace/pkg/tracing/span_processor.go:150
```