### PR TITLE
Fix SMTP options

### DIFF
--- a/pkg/alerting/notif_email.go
+++ b/pkg/alerting/notif_email.go
@@ -78,11 +78,7 @@ func NewEmailNotifier(app *bunapp.App) *EmailNotifier {
 
 	client, err := mail.NewClient(
 		conf.Host,
-		mail.WithPort(conf.Port),
-		mail.WithSMTPAuth(conf.AuthType),
-		mail.WithUsername(conf.Username),
-		mail.WithPassword(conf.Password),
-		mail.WithTLSPolicy(mail.TLSOpportunistic),
+		options...,
 	)
 	if err != nil {
 		app.Logger.Error("mail.NewClient failed", zap.Error(err))


### PR DESCRIPTION
In https://github.com/uptrace/uptrace/commit/63ee5f99afb4d5f004297d3504184e7cc8f36f02 an options slice was introduced which allows for disabling TLS (for local Uptrace running). 

Due to a bug, this `options` slice is never used however.. It was confusing to debug why my changes to the config weren't having the desired effect 😅 