### PR TITLE
fix: Webhook request parsing

### DIFF
--- a/pkg/alerting/notif_channel_handler.go
+++ b/pkg/alerting/notif_channel_handler.go
@@ -559,19 +559,20 @@ type WebhookMessage struct {
 
 func NewWebhookMessage(app *bunapp.App, alert org.Alert, payload any) *WebhookMessage {
 	baseAlert := alert.Base()
+	baseEvent := alert.GetEvent().Base()
 
 	msg := new(WebhookMessage)
 
-	msg.ID = baseAlert.Event.ID
-	msg.EventName = baseAlert.Event.Name
+	msg.ID = baseEvent.ID
+	msg.EventName = baseEvent.Name
 	msg.Payload = payload
-	msg.CreatedAt = baseAlert.Event.CreatedAt
+	msg.CreatedAt = baseEvent.CreatedAt
 
 	msg.Alert.ID = baseAlert.ID
 	msg.Alert.URL = app.SiteURL(baseAlert.URL())
 	msg.Alert.Name = baseAlert.Name
 	msg.Alert.Type = baseAlert.Type
-	msg.Alert.Status = baseAlert.Event.Status
+	msg.Alert.Status = baseEvent.Status
 	msg.Alert.CreatedAt = baseAlert.CreatedAt
 
 	return msg


### PR DESCRIPTION
When a webhook was modified or an alert was sent, a `runtime error: invalid memory address or nil pointer dereference` was raised at the moment the alert was parsed to create the webhook message:
```
github.com/uptrace/uptrace/pkg/alerting.NewWebhookMessage(0xc0004bcc60, {0x3613b20?, 0xc0005cd0e0?}, {0x17b0660, 0xc001d66900})
        github.com/uptrace/uptrace/pkg/alerting/notif_channel_handler.go:565 +0x57
github.com/uptrace/uptrace/pkg/alerting.notifyByWebhookChannel({0x3610a20, 0xc001d66660}, 0xc0004bcc60, 0x40?, {0x3613b20?, 0xc0005cd0e0?}, 0xc001d665d0)
        github.com/uptrace/uptrace/pkg/alerting/notif_webhook.go:58 +0x185
github.com/uptrace/uptrace/pkg/alerting.(*NotifChannelHandler).sendWebhookTestMsg(0xc0012d52b0, {0x3610a20, 0xc001d66660}, 0xc001c7d200, 0xc001d665d0)
        github.com/uptrace/uptrace/pkg/alerting/notif_channel_handler.go:476 +0x206
github.com/uptrace/uptrace/pkg/alerting.(*NotifChannelHandler).WebhookUpdate(0xc0012d52b0, {0x360d250, 0xc00343bb80}, {0xc001455b00, {{0xc000044c34, 0x37}, 0xc000749980, 0xc0012d5a20, 0x0}})
        github.com/uptrace/uptrace/pkg/alerting/notif_channel_handler.go:442 +0x232
```

By changing the way the `Event` inside the alert is accessed, the problem doesn't show anymore