### PR TITLE
fix: handle breadcrumbs with no `data`

### DIFF
--- a/pkg/tracing/sentry_handler.go
+++ b/pkg/tracing/sentry_handler.go
@@ -257,10 +257,11 @@ func (h *SentryHandler) newSpanFromBreadcrumb(bc *SentryBreadcrumb) *SpanEvent {
 	event.Time = bc.Timestamp.Time
 	event.Attrs = bc.Data
 
+	if event.Attrs == nil {
+		event.Attrs = NewAttrMap()
+	}
+
 	if bc.Type != "" {
-		if event.Attrs == nil {
-			event.Attrs = make(AttrMap)
-		}
 		event.Attrs["breadcrumb.type"] = bc.Type
 	}
 


### PR DESCRIPTION
We had an issue using the Sentry javascript client (`@sentry/solid`) where it would crash the uptrace server.

```
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
	/home/ante/.gvm/pkgsets/go1.22/global/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:398 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0012d6820, {0x0, 0x0, 0xc00ddcae00?})
	/home/ante/.gvm/pkgsets/go1.22/global/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:436 +0xa82
panic({0x17f7d60?, 0x362f5a0?})
	/home/ante/.gvm/gos/go1.22/src/runtime/panic.go:770 +0x132
github.com/uptrace/uptrace/pkg/tracing.initEventFromHostSpan(0xc000243680, 0x3649b98?, 0xc00e632b40)
	/home/ante/Desktop/repos/uptrace/pkg/tracing/span_attrs.go:508 +0x20e
github.com/uptrace/uptrace/pkg/tracing.(*spanProcessorThread)._processSpans(0xc007fe9f68, {0x3649b98, 0xc00f60e480}, {0xc000214f08, 0x58, 0x58?})
	/home/ante/Desktop/repos/uptrace/pkg/tracing/span_processor.go:197 +0x10f4
github.com/uptrace/uptrace/pkg/tracing.(*SpanProcessor).processSpans.func1()
	/home/ante/Desktop/repos/uptrace/pkg/tracing/span_processor.go:153 +0x1dc
created by github.com/uptrace/uptrace/pkg/tracing.(*SpanProcessor).processSpans in goroutine 115
	/home/ante/Desktop/repos/uptrace/pkg/tracing/span_processor.go:147 +0x165
```

We tracked down the issue to breadcrumbs Sentry is posting:

```
{
    // ...
    "breadcrumbs": [
        // ...
        {
            "timestamp": 1728033517.528,
            "category": "sentry.event",
            "event_id": "ada7b337b48b4157ba5cd52c066719c4",
            "message": "navigate"
        },
        {
            "timestamp": 1728034866.991,
            "category": "navigation",
            "data": {
                "from": "/devices/list",
                "to": "/monitoring/list"
            }
        },
        {
            "timestamp": 1728034866.962,
            "category": "sentry.transaction",
            "event_id": "21f89d7edca8408e91ffb624bf299d5d",
            "message": "21f89d7edca8408e91ffb624bf299d5d"
        },
    ]
}
```

When a breadcrumb had no data, `span_attrs.go:initEventFromHostSpan` failed because it accessed a nil map, while `sentry_handler.go:newSpanFromBreadcrumb` initializes an `Attrs` map only in the case if there is no type defined, just to set a `breadcrumb.type` value. This change makes sure the `Attrs` map for all spans created from sentry breadcrumbs is initialized.