### PR TITLE
fix span pagination

### DIFF
--- a/pkg/tracing/span_handler.go
+++ b/pkg/tracing/span_handler.go
@@ -65,7 +65,7 @@ func (h *SpanHandler) ListSpans(w http.ResponseWriter, req bunrouter.Request) er
 			order := string(chExpr) + " " + f.SortDir()
 			return q.OrderExpr(order)
 		}).
-		Limit(10).
+		Limit(15).
 		Offset(f.Pager.GetOffset())
 
 	ids := make([]SpanIdentity, 0)


### PR DESCRIPTION
Fix: #418
In the ListSpans handler, the limit of output rows was specified as 10 instead of 15.