### PR TITLE
Add "Test Alert" button for Notification Channels 

### DIFF
--- a/pkg/alerting/init.go
+++ b/pkg/alerting/init.go
@@ -81,12 +81,17 @@ func initRouter(ctx context.Context, app *bunapp.App) {
 
 			g.GET("/slack/:channel_id", handler.SlackShow)
 			g.PUT("/slack/:channel_id", handler.SlackUpdate)
+			g.POST("/slack/:channel_id", handler.SlackTest)
 
 			g.GET("/webhook/:channel_id", handler.WebhookShow)
 			g.PUT("/webhook/:channel_id", handler.WebhookUpdate)
+			g.POST("/webhook/:channel_id", handler.WebhookTest)
 
 			g.GET("/telegram/:channel_id", handler.TelegramShow)
 			g.PUT("/telegram/:channel_id", handler.TelegramUpdate)
+			g.POST("/telegram/:channel_id", handler.TelegramTest)
+
+			// g.POST("/alertmanager/:channel_id", handler.WebhookTest)
 		})
 }
 

--- a/pkg/alerting/init.go
+++ b/pkg/alerting/init.go
@@ -78,20 +78,16 @@ func initRouter(ctx context.Context, app *bunapp.App) {
 			g.DELETE("/:channel_id", handler.Delete)
 			g.PUT("/:channel_id/paused", handler.Pause)
 			g.PUT("/:channel_id/unpaused", handler.Unpause)
+			g.POST("/:channel_id/test", handler.ChannelTest)
 
 			g.GET("/slack/:channel_id", handler.SlackShow)
 			g.PUT("/slack/:channel_id", handler.SlackUpdate)
-			g.POST("/slack/:channel_id", handler.SlackTest)
 
 			g.GET("/webhook/:channel_id", handler.WebhookShow)
 			g.PUT("/webhook/:channel_id", handler.WebhookUpdate)
-			g.POST("/webhook/:channel_id", handler.WebhookTest)
 
 			g.GET("/telegram/:channel_id", handler.TelegramShow)
 			g.PUT("/telegram/:channel_id", handler.TelegramUpdate)
-			g.POST("/telegram/:channel_id", handler.TelegramTest)
-
-			// g.POST("/alertmanager/:channel_id", handler.WebhookTest)
 		})
 }
 

--- a/pkg/alerting/notif_channel_handler.go
+++ b/pkg/alerting/notif_channel_handler.go
@@ -97,6 +97,28 @@ func (h *NotifChannelHandler) UpdateNotifChannelState(
 	})
 }
 
+func (h *NotifChannelHandler) ChannelTest(w http.ResponseWriter, req bunrouter.Request) error {
+	ctx := req.Context()
+
+	baseChannel := NotifChannelFromContext(ctx).Base()
+
+	switch baseChannel.Type {
+	case NotifChannelAlertmanager:
+		//TODO:
+		return nil
+	case NotifChannelSlack:
+		return h.slackTest(w, req)
+
+	case NotifChannelTelegram:
+		return h.telegramTest(w, req)
+
+	case NotifChannelWebhook:
+		return h.webhookTest(w, req)
+
+	}
+	return fmt.Errorf("unexpected notification channel: %T", baseChannel)
+}
+
 //------------------------------------------------------------------------------
 
 func (h *NotifChannelHandler) SlackShow(w http.ResponseWriter, req bunrouter.Request) error {
@@ -201,7 +223,7 @@ func (h *NotifChannelHandler) SlackUpdate(w http.ResponseWriter, req bunrouter.R
 	})
 }
 
-func (h *NotifChannelHandler) SlackTest(w http.ResponseWriter, req bunrouter.Request) error {
+func (h *NotifChannelHandler) slackTest(w http.ResponseWriter, req bunrouter.Request) error {
 	ctx := req.Context()
 
 	channel, err := SlackNotifChannelFromContext(ctx)
@@ -233,7 +255,7 @@ func (h *NotifChannelHandler) sendSlackTestMsg(channel *SlackNotifChannel) error
 	}
 
 	msg := &slack.WebhookMessage{
-		Text: fmt.Sprintf("Test message from Uptrace"),
+		Text: "Test message from Uptrace",
 	}
 	if err := slack.PostWebhook(webhookURL, msg); err != nil {
 		return err
@@ -310,7 +332,7 @@ func (h *NotifChannelHandler) TelegramCreate(w http.ResponseWriter, req bunroute
 	})
 }
 
-func (h *NotifChannelHandler) TelegramTest(w http.ResponseWriter, req bunrouter.Request) error {
+func (h *NotifChannelHandler) telegramTest(w http.ResponseWriter, req bunrouter.Request) error {
 	ctx := req.Context()
 	project := org.ProjectFromContext(ctx)
 
@@ -320,7 +342,6 @@ func (h *NotifChannelHandler) TelegramTest(w http.ResponseWriter, req bunrouter.
 			Type:      NotifChannelTelegram,
 		},
 	}
-
 	in := new(TelegramNotifChannelIn)
 	if err := httputil.UnmarshalJSON(w, req, &in, 10<<10); err != nil {
 		return err
@@ -505,7 +526,7 @@ func (h *NotifChannelHandler) WebhookUpdate(w http.ResponseWriter, req bunrouter
 	})
 }
 
-func (h *NotifChannelHandler) WebhookTest(w http.ResponseWriter, req bunrouter.Request) error {
+func (h *NotifChannelHandler) webhookTest(w http.ResponseWriter, req bunrouter.Request) error {
 	ctx := req.Context()
 	project := org.ProjectFromContext(ctx)
 

--- a/pkg/tracing/span_handler.go
+++ b/pkg/tracing/span_handler.go
@@ -65,7 +65,7 @@ func (h *SpanHandler) ListSpans(w http.ResponseWriter, req bunrouter.Request) er
 			order := string(chExpr) + " " + f.SortDir()
 			return q.OrderExpr(order)
 		}).
-		Limit(10).
+		Limit(15).
 		Offset(f.Pager.GetOffset())
 
 	ids := make([]SpanIdentity, 0)

--- a/vue/src/alerting/NotifChannelsTableRow.vue
+++ b/vue/src/alerting/NotifChannelsTableRow.vue
@@ -6,6 +6,14 @@
       <NotifChannelStateAvatar :state="channel.state" class="mr-2" />
     </td>
     <td class="text-center">
+      <v-btn 
+      :loading="man.pending"     
+      icon
+      title="Test channel"
+      @click.stop="testChannel(channel)"
+      >
+      <v-icon>mdi-message-alert</v-icon>
+      </v-btn>
       <v-btn
         v-if="channel.state === NotifChannelState.Delivering"
         :loading="man.pending"
@@ -71,6 +79,12 @@ export default defineComponent({
     const confirm = useConfirm()
     const man = useNotifChannelManager()
 
+    function testChannel(channel: NotifChannel) {
+      man.test(channel.id, channel).then(() => {
+        ctx.emit('change')
+      })
+    }
+
     function pauseChannel(channel: NotifChannel) {
       man.pause(channel.id).then(() => {
         ctx.emit('change')
@@ -113,6 +127,7 @@ export default defineComponent({
       NotifChannelState,
 
       man,
+      testChannel,
       pauseChannel,
       unpauseChannel,
       deleteChannel,

--- a/vue/src/alerting/use-notif-channels.ts
+++ b/vue/src/alerting/use-notif-channels.ts
@@ -219,7 +219,7 @@ export function useNotifChannelManager() {
 
   function test(channelId: number, channel: NotifChannel) {
     const { projectId } = route.value.params
-    const url = `/internal/v1/projects/${projectId}/notification-channels/${channel.type}/${channelId}`
+    const url = `/internal/v1/projects/${projectId}/notification-channels/${channelId}/test`
     return request({ method: 'POST', url, data: channel }).then((resp) => {
       return resp.data.channel
     })

--- a/vue/src/alerting/use-notif-channels.ts
+++ b/vue/src/alerting/use-notif-channels.ts
@@ -217,6 +217,14 @@ export function useNotifChannelManager() {
   const route = useRoute()
   const { loading: pending, request } = useAxios()
 
+  function test(channelId: number, channel: NotifChannel) {
+    const { projectId } = route.value.params
+    const url = `/internal/v1/projects/${projectId}/notification-channels/${channel.type}/${channelId}`
+    return request({ method: 'POST', url, data: channel }).then((resp) => {
+      return resp.data.channel
+    })
+  }
+
   function pause(channelId: number) {
     const { projectId } = route.value.params
     const url = `/internal/v1/projects/${projectId}/notification-channels/${channelId}/paused`
@@ -305,7 +313,7 @@ export function useNotifChannelManager() {
 
   return proxyRefs({
     pending,
-
+    test,
     pause,
     unpause,
     delete: del,


### PR DESCRIPTION
Added handlers for sending a test message to Telegram, Slack, Webhook.
Issue #381