### PR TITLE
chore: replace zeebo/xxh3 with cespare/xxhash/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/wneessen/go-mail v0.4.3
 	github.com/xhit/go-str2duration/v2 v2.1.0
-	github.com/zeebo/xxh3 v1.0.2
 	github.com/zyedidia/generic v1.2.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0
@@ -144,7 +143,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,6 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
 github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/48xc=
-github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b h1:udzkj9S/zlT5X367kqJis0QP7YMxobob6zhzq6Yre00=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -629,10 +627,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
-github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
-github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
-github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zyedidia/generic v1.2.1 h1:Zv5KS/N2m0XZZiuLS82qheRG4X1o5gsWreGb0hR7XDc=
 github.com/zyedidia/generic v1.2.1/go.mod h1:ly2RBz4mnz1yeuVbQA/VFwGjK3mnHGRj1JuoG336Bis=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=

--- a/pkg/metrics/mql/engine.go
+++ b/pkg/metrics/mql/engine.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/uptrace/uptrace/pkg/bunconv"
 	"github.com/uptrace/uptrace/pkg/metrics/mql/ast"
 	"github.com/uptrace/uptrace/pkg/unixtime"
-	"github.com/zeebo/xxh3"
 	"go4.org/syncutil"
 )
 
@@ -339,7 +339,7 @@ func (e *Engine) fullJoin(
 	m := e.makeTimeseriesMap(joined, grouping)
 	for _, rhsTs := range rhs {
 		e.buf = rhsTs.Attrs.Bytes(e.buf[:0], grouping)
-		hash := xxh3.Hash(e.buf)
+		hash := xxhash.Sum64(e.buf)
 
 		lhsTs, ok := m[hash]
 		if !ok {
@@ -368,7 +368,7 @@ func (e *Engine) oneToManyJoin(
 	m := e.makeTimeseriesMap(lhs, grouping)
 	for _, rhsTs := range rhs {
 		e.buf = rhsTs.Attrs.Bytes(e.buf[:0], grouping)
-		hash := xxh3.Hash(e.buf)
+		hash := xxhash.Sum64(e.buf)
 
 		var lhsValue []float64
 		if lhsTs, ok := m[hash]; ok {
@@ -406,7 +406,7 @@ func (e *Engine) makeTimeseriesMap(
 	m := make(map[uint64]*Timeseries, len(timeseries))
 	for _, ts := range timeseries {
 		e.buf = ts.Attrs.Bytes(e.buf[:0], grouping)
-		hash := xxh3.Hash(e.buf)
+		hash := xxhash.Sum64(e.buf)
 		m[hash] = ts
 	}
 	return m
@@ -711,7 +711,7 @@ func (e *Engine) callAggFunc(fn *FuncCall, op aggFunc) ([]*Timeseries, error) {
 	grouping := makeSet(fn.Grouping...)
 	for _, ts := range timeseries {
 		e.buf = ts.Attrs.Bytes(e.buf[:0], grouping)
-		hash := xxh3.Hash(e.buf)
+		hash := xxhash.Sum64(e.buf)
 
 		if _, ok := m[hash]; !ok {
 			hashes = append(hashes, hash)

--- a/pkg/metrics/query_handler.go
+++ b/pkg/metrics/query_handler.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/zeebo/xxh3"
+	"github.com/cespare/xxhash/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/fx"
@@ -199,7 +199,7 @@ func convertToTable(
 		}
 
 		buf = ts.Attrs.Bytes(buf[:0], nil)
-		hash := xxh3.Hash(buf)
+		hash := xxhash.Sum64(buf)
 
 		row, ok := rowMap[hash]
 		if !ok {
@@ -210,7 +210,7 @@ func convertToTable(
 			row["_query"] = ts.WhereQuery()
 
 			buf = ts.Attrs.Bytes(buf[:0], nil)
-			row["_hash"] = strconv.FormatUint(xxh3.Hash(buf), 10)
+			row["_hash"] = strconv.FormatUint(xxhash.Sum64(buf), 10)
 
 			for _, kv := range ts.Attrs {
 				if _, ok := columnMap[kv.Key]; !ok {
@@ -350,7 +350,7 @@ func (h *QueryHandler) Timeseries(w http.ResponseWriter, req bunrouter.Request) 
 		dest := &jsonTimeseries[i]
 
 		name := src.Name()
-		dest.ID = xxh3.HashString(name)
+		dest.ID = xxhash.Sum64String(name)
 		dest.Name = name
 		dest.Metric = src.MetricName
 		dest.Unit = src.Unit


### PR DESCRIPTION
Currently we are using two packages for xxHash:

1. https://github.com/uptrace/uptrace/blob/72adfe68e46d5c9734b238c4db528d12be3a0956/go.mod#L19

2. https://github.com/uptrace/uptrace/blob/72adfe68e46d5c9734b238c4db528d12be3a0956/go.mod#L59

We should stick to just one library for xxHash.

`github.com/cespare/xxhash/v2` is the one that is more popular and has more usages in the code base. This PR replaces `github.com/zeebo/xxh3` with `github.com/cespare/xxhash/v2`.