### PR TITLE
pkg/bunapp/app.go: Refactor tracing errors and update gRPC stats handler

### DIFF
--- a/pkg/bunapp/app.go
+++ b/pkg/bunapp/app.go
@@ -183,8 +183,7 @@ func initGRPC(conf *bunconf.Config) (*grpc.Server, error) {
 	var opts []grpc.ServerOption
 
 	opts = append(opts,
-		grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor()),
-		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.MaxRecvMsgSize(32<<20),
 		grpc.ReadBufferSize(512<<10),
 	)

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -1,27 +1,9 @@
 package metrics
 
-import (
-	"golang.org/x/exp/constraints"
-)
-
 func listToSet(ss []string) map[string]struct{} {
 	m := make(map[string]struct{}, len(ss))
 	for _, s := range ss {
 		m[s] = struct{}{}
 	}
 	return m
-}
-
-func min[T constraints.Ordered](a, b T) T {
-	if a <= b {
-		return a
-	}
-	return b
-}
-
-func max[T constraints.Ordered](a, b T) T {
-	if a >= b {
-		return a
-	}
-	return b
 }

--- a/pkg/tracing/span.go
+++ b/pkg/tracing/span.go
@@ -135,13 +135,13 @@ func (s *Span) TreeEndTime() time.Time {
 }
 
 var (
-	walkBreak     = errors.New("BREAK")
-	walkNextChild = errors.New("NEXT-CHILD")
+	errWalkBreak     = errors.New("BREAK")
+	errWalkNextChild = errors.New("NEXT-CHILD")
 )
 
 func (s *Span) Walk(fn func(child, parent *Span) error) error {
 	if err := fn(s, nil); err != nil {
-		if err != walkBreak {
+		if err != errWalkBreak {
 			return err
 		}
 		return nil
@@ -152,7 +152,7 @@ func (s *Span) Walk(fn func(child, parent *Span) error) error {
 func (s *Span) walkChildren(fn func(child, parent *Span) error) error {
 	for _, child := range s.Children {
 		if err := fn(child, s); err != nil {
-			if err == walkNextChild {
+			if err == errWalkNextChild {
 				continue
 			}
 			return err

--- a/pkg/tracing/trace_handler.go
+++ b/pkg/tracing/trace_handler.go
@@ -104,7 +104,7 @@ func (h *TraceHandler) ShowTrace(w http.ResponseWriter, req bunrouter.Request) e
 			if span.ID == rootSpanID {
 				span.ParentID = 0
 				root = span
-				return walkBreak
+				return errWalkBreak
 			}
 			return nil
 		})


### PR DESCRIPTION
Replaces gRPC interceptors with StatsHandler in app initialization for improved OpenTelemetry integration.

all: Renames walkBreak and walkNextChild errors to errWalkBreak and errWalkNextChild for clarity and consistency in tracing.

all: Removes unused generic min and max functions from metrics/util.go.