### PR TITLE
fix(dashboard): add missing $ prefix on avail_bytes variable

### DIFF
--- a/config/dashboard-templates/uptrace.node_exporter.10.cpu_ram.yml
+++ b/config/dashboard-templates/uptrace.node_exporter.10.cpu_ram.yml
@@ -75,7 +75,7 @@ grid_rows:
           - node_filesystem_avail_bytes as $avail_bytes
           - node_filesystem_size_bytes as $size_bytes
         query:
-          - 1 - sum(avail_bytes{mountpoint="/",fstype!="rootfs"}) /
+          - 1 - sum($avail_bytes{mountpoint="/",fstype!="rootfs"}) /
             sum($size_bytes{mountpoint="/",fstype!="rootfs"}) as fs_used
         columns:
           fs_used: { unit: utilization }


### PR DESCRIPTION
The node_exporter CPU & RAM dashboard references `avail_bytes` without the `$` prefix in the Root FS used gauge query, so the metric alias is not resolved.