### PR TITLE
fix: negate scale exponent in exponential histogram base calculation

### DIFF
--- a/pkg/metrics/otlp.go
+++ b/pkg/metrics/otlp.go
@@ -367,7 +367,7 @@ func (p *otlpProcessor) otlpExpHistogram(
 		if dp.ZeroCount > 0 {
 			hist[bfloat16.From(0)] += dp.ZeroCount
 		}
-		base := math.Pow(2, math.Pow(2, float64(dp.Scale)))
+		base := math.Pow(2, math.Pow(2, -float64(dp.Scale)))
 		buildBFloat16Hist(hist, base, int(dp.Positive.Offset), dp.Positive.BucketCounts, +1)
 		buildBFloat16Hist(hist, base, int(dp.Negative.Offset), dp.Negative.BucketCounts, -1)
 


### PR DESCRIPTION
Fixes #592

The [OTel spec](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram) defines the exponential histogram base as `2^(2^(-scale))`. We were computing `2^(2^(+scale))`, which produces garbage bucket boundaries for high scale values (10^38+).

One character fix: negate the scale exponent.