### PR TITLE
feat: add explicit log TTL support and configuration

### DIFF
--- a/cmd/uptrace/command/ch.go
+++ b/cmd/uptrace/command/ch.go
@@ -123,6 +123,9 @@ func NewCHMigrator(conf *bunconf.Config, chdb *ch.DB, migrations *chmigrate.Migr
 	args["SPANS_STORAGE"] = defaultValue(chSchema.Spans.StoragePolicy, "default")
 	args["SPANS_TTL"] = ch.Safe(chSchema.Spans.TTLDelete)
 
+	args["LOGS_STORAGE"] = defaultValue(chSchema.Logs.StoragePolicy, "default")
+	args["LOGS_TTL"] = ch.Safe(chSchema.Logs.TTLDelete)
+
 	args["METRICS_STORAGE"] = defaultValue(chSchema.Metrics.StoragePolicy, "default")
 	args["METRICS_TTL"] = ch.Safe(chSchema.Metrics.TTLDelete)
 

--- a/cmd/uptrace/command/ch_schema.go
+++ b/cmd/uptrace/command/ch_schema.go
@@ -67,6 +67,11 @@ func chSchemaTTLMove(lc fx.Lifecycle, c *cli.Context, conf *bunconf.Config, chdb
 			if storage == "" {
 				storage = chSchema.Spans.StoragePolicy
 			}
+		case "logs_data", "logs_index":
+			ttlDelete = chSchema.Logs.TTLDelete
+			if storage == "" {
+				storage = chSchema.Logs.StoragePolicy
+			}
 		case "datapoint_minutes", "datapoint_hours":
 			ttlDelete = chSchema.Metrics.TTLDelete
 			if storage == "" {

--- a/cmd/uptrace/command/ch_test.go
+++ b/cmd/uptrace/command/ch_test.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/uptrace/pkg/clickhouse/ch"
+	"github.com/uptrace/pkg/clickhouse/chmigrate"
+	"github.com/uptrace/uptrace/pkg/bunconf"
+)
+
+func TestNewCHMigratorLogsSchemaArgs(t *testing.T) {
+	t.Run("uses logs settings", func(t *testing.T) {
+		conf := new(bunconf.Config)
+		conf.CHSchema.Spans.TTLDelete = "30 DAY"
+		conf.CHSchema.Spans.StoragePolicy = "spans"
+		conf.CHSchema.Logs.TTLDelete = "3 DAY"
+		conf.CHSchema.Logs.StoragePolicy = "logs"
+
+		got := formatLogsSchemaArgs(t, conf)
+		if want := "3 DAY|'logs'"; got != want {
+			t.Fatalf("formatted logs schema args = %q, want %q", got, want)
+		}
+	})
+
+}
+
+func formatLogsSchemaArgs(t *testing.T, conf *bunconf.Config) string {
+	t.Helper()
+
+	chdb := ch.Connect()
+	t.Cleanup(func() {
+		if err := chdb.Close(); err != nil {
+			t.Errorf("closing ClickHouse client: %v", err)
+		}
+	})
+
+	migrator := NewCHMigrator(conf, chdb, chmigrate.NewMigrations())
+	return migrator.DB().Formatter().FormatQuery("?LOGS_TTL|?LOGS_STORAGE")
+}

--- a/config/uptrace.dist.yml
+++ b/config/uptrace.dist.yml
@@ -78,24 +78,11 @@ ch_schema:
   # Compression codec, for example, LZ4, ZSTD(1), or Default.
   compression: ZSTD(1)
 
-  spans_index:
-    storage_policy: 'default'
-    ttl_delete: 14 DAY
-  spans_data:
+  spans:
     storage_policy: 'default'
     ttl_delete: 14 DAY
 
-  logs_index:
-    storage_policy: 'default'
-    ttl_delete: 14 DAY
-  logs_data:
-    storage_policy: 'default'
-    ttl_delete: 14 DAY
-
-  events_index:
-    storage_policy: 'default'
-    ttl_delete: 14 DAY
-  events_data:
+  logs:
     storage_policy: 'default'
     ttl_delete: 14 DAY
 

--- a/config/uptrace.dist.yml
+++ b/config/uptrace.dist.yml
@@ -78,11 +78,21 @@ ch_schema:
   # Compression codec, for example, LZ4, ZSTD(1), or Default.
   compression: ZSTD(1)
 
-  spans:
+  spans_index:
+    storage_policy: 'default'
+    ttl_delete: 14 DAY
+  spans_data:
     storage_policy: 'default'
     ttl_delete: 14 DAY
 
   logs:
+    storage_policy: 'default'
+    ttl_delete: 14 DAY
+
+  events_index:
+    storage_policy: 'default'
+    ttl_delete: 14 DAY
+  events_data:
     storage_policy: 'default'
     ttl_delete: 14 DAY
 

--- a/config/uptrace.yml
+++ b/config/uptrace.yml
@@ -136,6 +136,11 @@ ch_schema:
     ttl_delete: 7 DAY
     storage_policy: 'default'
 
+  logs:
+    # Delete logs data after 7 days.
+    ttl_delete: 7 DAY
+    storage_policy: 'default'
+
   metrics:
     # Delete metrics data after 90 days.
     ttl_delete: 30 DAY

--- a/example/docker/uptrace.yml
+++ b/example/docker/uptrace.yml
@@ -214,16 +214,16 @@ ch_schema:
   # - Default: ClickHouse default compression
   compression: ZSTD(1)
 
-  # Storage policies for different data types
-  # Allows using different storage tiers (SSD, HDD, S3) for different data
-  spans_index: { storage_policy: default }   # Span search indexes
-  spans_data: { storage_policy: default }    # Raw span data
-  span_links: { storage_policy: default }    # Span relationship data
-  logs_index: { storage_policy: default }    # Log search indexes
-  logs_data: { storage_policy: default }     # Raw log data
-  events_index: { storage_policy: default }  # Event search indexes
-  events_data: { storage_policy: default }   # Raw event data
-  metrics: { storage_policy: default }       # Metrics time-series data
+  # Retention and storage policies for different data types.
+  spans:
+    ttl_delete: 30 DAY
+    storage_policy: default
+  logs:
+    ttl_delete: 30 DAY
+    storage_policy: default
+  metrics:
+    ttl_delete: 90 DAY
+    storage_policy: default
 
 # -----------------------------------------------------------------------------
 # Redis Cache Configuration

--- a/example/docker/uptrace.yml
+++ b/example/docker/uptrace.yml
@@ -214,16 +214,17 @@ ch_schema:
   # - Default: ClickHouse default compression
   compression: ZSTD(1)
 
-  # Retention and storage policies for different data types.
-  spans:
-    ttl_delete: 30 DAY
-    storage_policy: default
+  # Storage policies for different data types
+  # Allows using different storage tiers (SSD, HDD, S3) for different data
+  spans_index: { storage_policy: default }   # Span search indexes
+  spans_data: { storage_policy: default }    # Raw span data
+  span_links: { storage_policy: default }    # Span relationship data
   logs:
     ttl_delete: 30 DAY
     storage_policy: default
-  metrics:
-    ttl_delete: 90 DAY
-    storage_policy: default
+  events_index: { storage_policy: default }  # Event search indexes
+  events_data: { storage_policy: default }   # Raw event data
+  metrics: { storage_policy: default }       # Metrics time-series data
 
 # -----------------------------------------------------------------------------
 # Redis Cache Configuration

--- a/example/kvrocks/uptrace.yml
+++ b/example/kvrocks/uptrace.yml
@@ -219,6 +219,11 @@ ch_schema:
     # Delete spans data after 30 days.
     ttl_delete: 30 DAY
 
+  logs:
+    storage_policy: 'default'
+    # Delete logs data after 30 days.
+    ttl_delete: 30 DAY
+
   metrics:
     storage_policy: 'default'
     # Delete metrics data after 90 days.

--- a/example/redis-enterprise/uptrace.yml
+++ b/example/redis-enterprise/uptrace.yml
@@ -139,6 +139,11 @@ ch_schema:
     # Delete spans data after 30 days.
     ttl_delete: 30 DAY
 
+  logs:
+    storage_policy: 'default'
+    # Delete logs data after 30 days.
+    ttl_delete: 30 DAY
+
   metrics:
     storage_policy: 'default'
     # Delete metrics data after 90 days.

--- a/pkg/bunapp/chmigrations/20260805120407_logs_ttl.down.sql
+++ b/pkg/bunapp/chmigrations/20260805120407_logs_ttl.down.sql
@@ -1,0 +1,17 @@
+ALTER TABLE ?DB.logs_index ?ON_CLUSTER
+MODIFY SETTING storage_policy = ?SPANS_STORAGE
+
+--migration:split
+
+ALTER TABLE ?DB.logs_index ?ON_CLUSTER
+MODIFY TTL toDate(time) + INTERVAL ?SPANS_TTL DELETE
+
+--migration:split
+
+ALTER TABLE ?DB.logs_data ?ON_CLUSTER
+MODIFY SETTING storage_policy = ?SPANS_STORAGE
+
+--migration:split
+
+ALTER TABLE ?DB.logs_data ?ON_CLUSTER
+MODIFY TTL toDate(time) + INTERVAL ?SPANS_TTL DELETE

--- a/pkg/bunapp/chmigrations/20260805120407_logs_ttl.up.sql
+++ b/pkg/bunapp/chmigrations/20260805120407_logs_ttl.up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE ?DB.logs_index ?ON_CLUSTER
+MODIFY SETTING storage_policy = ?LOGS_STORAGE
+
+--migration:split
+
+ALTER TABLE ?DB.logs_index ?ON_CLUSTER
+MODIFY TTL toDate(time) + INTERVAL ?LOGS_TTL DELETE
+
+--migration:split
+
+ALTER TABLE ?DB.logs_data ?ON_CLUSTER
+MODIFY SETTING storage_policy = ?LOGS_STORAGE
+
+--migration:split
+
+ALTER TABLE ?DB.logs_data ?ON_CLUSTER
+MODIFY TTL toDate(time) + INTERVAL ?LOGS_TTL DELETE

--- a/pkg/bunconf/config.go
+++ b/pkg/bunconf/config.go
@@ -90,6 +90,8 @@ func defaultConfig() *Config {
 	conf.CHSchema.Compression = "ZSTD(3)"
 	conf.CHSchema.Spans.TTLDelete = "30 DAY"
 	conf.CHSchema.Spans.StoragePolicy = "default"
+	conf.CHSchema.Logs.TTLDelete = "30 DAY"
+	conf.CHSchema.Logs.StoragePolicy = "default"
 	conf.CHSchema.Metrics.TTLDelete = "90 DAY"
 	conf.CHSchema.Metrics.StoragePolicy = "default"
 
@@ -340,6 +342,11 @@ type Config struct {
 			StoragePolicy string `yaml:"storage_policy"`
 			TTLDelete     string `yaml:"ttl_delete"`
 		} `yaml:"spans"`
+
+		Logs struct {
+			StoragePolicy string `yaml:"storage_policy"`
+			TTLDelete     string `yaml:"ttl_delete"`
+		} `yaml:"logs"`
 
 		Metrics struct {
 			StoragePolicy string `yaml:"storage_policy"`

--- a/pkg/bunconf/config_test.go
+++ b/pkg/bunconf/config_test.go
@@ -1,0 +1,48 @@
+package bunconf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadConfigLogsSchema(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "uptrace.yml")
+	confYAML := []byte(`
+ch_schema:
+  spans:
+    ttl_delete: 30 DAY
+    storage_policy: spans
+  logs:
+    ttl_delete: 3 DAY
+    storage_policy: logs
+`)
+	if err := os.WriteFile(confPath, confYAML, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	conf, err := ReadConfig(confPath, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := conf.CHSchema.Logs.TTLDelete, "3 DAY"; got != want {
+		t.Fatalf("Logs.TTLDelete = %q, want %q", got, want)
+	}
+	if got, want := conf.CHSchema.Logs.StoragePolicy, "logs"; got != want {
+		t.Fatalf("Logs.StoragePolicy = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultConfigLogsSchema(t *testing.T) {
+	conf := defaultConfig()
+	conf.CHSchema.Spans.TTLDelete = "14 DAY"
+	conf.CHSchema.Spans.StoragePolicy = "spans"
+
+	if got, want := conf.CHSchema.Logs.TTLDelete, "30 DAY"; got != want {
+		t.Fatalf("Logs.TTLDelete = %q, want %q", got, want)
+	}
+	if got, want := conf.CHSchema.Logs.StoragePolicy, "default"; got != want {
+		t.Fatalf("Logs.StoragePolicy = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Seems like the TTL configuration for logs is already implicitly supported but inherited from the spans configuration. This PR allows to set it explicitly.

## Summary

- Add independent `ch_schema.logs.ttl_delete` and `storage_policy` configuration, defaulting to `30 DAY` and `default`.
- Add `LOGS_TTL` and `LOGS_STORAGE` ClickHouse migration parameters.
- Add a forward migration updating TTL and storage policy for both `logs_index` and `logs_data`, with clustered deployment support and rollback to the previous spans policy.
- Extend `ch_schema ttl_move` to support log tables.
- Update shipped configs/examples and add configuration and migrator tests.
- Leave historical migrations unchanged.

The migration handles fresh and existing databases once; subsequent config changes still require an explicit `ALTER TABLE`.